### PR TITLE
add: merge-gatekeeperの設定方法を追加

### DIFF
--- a/docs/雑多なメモ.md
+++ b/docs/雑多なメモ.md
@@ -1,2 +1,49 @@
-* Organization secrets/variables
-  * `DISCORD_WEBHOOK_URL`: VOICEVOX非公式Discordの`#github`へチャンネルに届くwebhook url
+## Organization secrets/variables
+
+- `DISCORD_WEBHOOK_URL`: VOICEVOX 非公式 Discord の`#github`へチャンネルに届く webhook url
+- `GATEKEEPER_TOKEN`: [`merge-gatekeeper`](https://github.com/VOICEVOX/merge-gatekeeper)に必要なトークン
+
+## Auto merge & merge queue
+
+[`merge-gatekeeper`](https://github.com/VOICEVOX/merge-gatekeeper)を活用することで、VOICEVOX レビューの複雑なマージ可能判定を反映しつつ、オートマージ・マージキューを設定できます。
+
+`.github/workflows/merge_gatekeeper.yml`に以下のような Github workflow ファイルを作ります。
+`required_score`や`score_rules`、kebab-case にするかなどはリポジトリのルールに合わせます。
+
+```yaml
+name: "Merge Gatekeeper"
+
+# auto mergeとmerge queue用のチェッカー。
+# Approve数が足りているか、すべてのテストが通っているかを確認します。
+# 詳細： https://github.com/VOICEVOX/merge-gatekeeper
+
+on:
+  pull_request_target:
+    types: [auto_merge_enabled]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  merge_gatekeeper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: voicevox/merge-gatekeeper@main
+        with:
+          token: ${{ secrets.GATEKEEPER_TOKEN }}
+          required_score: 2
+          score_rules: |
+            #maintainer: 2
+            #reviewer: 1
+      - uses: upsidr/merge-gatekeeper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          self: merge_gatekeeper
+          # https://github.com/upsidr/merge-gatekeeper/issues/71#issuecomment-1660607977
+          ref: ${{ github.event.pull_request && github.event.pull_request.head.sha || github.ref }}
+          timeout: 18000 # 5 hours
+```
+
+ワークフローファイルを作った後に一度メインブランチにマージします。
+
+リポジトリの設定の Allow auto-merge を有効にし、
+[`merge-gatekeeper`](https://github.com/VOICEVOX/merge-gatekeeper)の Ruleset をエクスポートしてリポジトリにインポートすれば設定完了です。

--- a/docs/雑多なメモ.md
+++ b/docs/雑多なメモ.md
@@ -46,4 +46,25 @@ jobs:
 ワークフローファイルを作った後に一度メインブランチにマージします。
 
 リポジトリの設定の Allow auto-merge を有効にし、
-[`merge-gatekeeper`](https://github.com/VOICEVOX/merge-gatekeeper)の Ruleset をエクスポートしてリポジトリにインポートすれば設定完了です。
+[`merge-gatekeeper`](https://github.com/VOICEVOX/merge-gatekeeper)の Ruleset をエクスポートしてリポジトリにインポートします。
+
+テストしたい Github ワークフローに対し、`gh-readonly-queue/*`ブランチへの push トリガーか、merge_group イベントのトリガーを追加します。
+例えば以下のうちいずれかを追加します。
+
+```yaml
+on:
+  push:
+```
+
+```yaml
+on:
+  push:
+    branches:
+      - "gh-readonly-queue/*"
+```
+
+```yaml
+on:
+  merge_group:
+    types: [checks_requested]
+```


### PR DESCRIPTION
## 内容

[`merge-gatekeeper`](https://github.com/VOICEVOX/merge-gatekeeper)を設定する方法をドキュメントに追加します。
たぶんこれでいけるはず。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/issues/53
- https://github.com/VOICEVOX/voicevox_blog/issues/253

## その他

ちなみにmerge-queueを使えるのはGithubの制約によりメインブランチのみです
（`release-*`ブランチとかにはauto-mergeしか使えないので、今までと同じ運用になるはず。）
