### PR TITLE
docs: dockerhubのlatestの更新工程を追加

### DIFF
--- a/docs/hotfix確認作業テンプレート.md
+++ b/docs/hotfix確認作業テンプレート.md
@@ -33,7 +33,16 @@
     - [ ] ブログの更新
     - [ ] ブログのmainマージ（アプデ通知のため）
 - [ ] 後処理
-  - [ ] リソースのreleaseブランチをマージ
-  - [ ] コアのreleaseブランチをマージ
-  - [ ] エンジンのreleaseブランチをマージ
-  - [ ] ソフトウェアのreleaseブランチをマージ
+  - [ ] リソース
+    - [ ] releaseブランチをマージ
+    - [ ] releasesを更新
+  - [ ] コア
+    - [ ] releaseブランチをマージ
+    - [ ] releasesを更新
+  - [ ] エンジン
+    - [ ] releaseブランチをマージ
+    - [ ] releasesを更新
+    - [ ] Docker Hubのlatestを更新
+  - [ ] ソフトウェア
+    - [ ] releaseブランチをマージ
+    - [ ] releasesを更新

--- a/docs/アップデート確認作業テンプレート.md
+++ b/docs/アップデート確認作業テンプレート.md
@@ -45,7 +45,16 @@
   - [ ] エンジンのクエリパラメータ変更
   - [ ] 目玉機能の動画をぶら下げ
 - [ ] 後処理
-  - [ ] リソースのreleaseブランチをマージ
-  - [ ] コアのreleaseブランチをマージ
-  - [ ] エンジンのreleaseブランチをマージ
-  - [ ] ソフトウェアのreleaseブランチをマージ
+  - [ ] リソース
+    - [ ] releaseブランチをマージ
+    - [ ] releasesを更新
+  - [ ] コア
+    - [ ] releaseブランチをマージ
+    - [ ] releasesを更新
+  - [ ] エンジン
+    - [ ] releaseブランチをマージ
+    - [ ] releasesを更新
+    - [ ] Docker Hubのlatestを更新
+  - [ ] ソフトウェア
+    - [ ] releaseブランチをマージ
+    - [ ] releasesを更新


### PR DESCRIPTION
## 内容

VOICEVOX ENGINEはdocker buildのpushとlatestの更新の工程が別れました。
それを手順書に反映しておこうと思います。

## その他
