### PR TITLE
docs: 簡易規約文面をreadme4箇所ほどに転機する内容を追記

### DIFF
--- a/docs/hotfix確認作業テンプレート.md
+++ b/docs/hotfix確認作業テンプレート.md
@@ -6,6 +6,7 @@
   - [ ] RESOURCEの更新
     - [ ] policy.mdの更新
     - [ ] character_info内のmetas.jsonの更新
+    - [ ] 簡易規約文面をreadme 4箇所ほどに転機
   - [ ] リリース
 - [ ] コアアップデート
   - [ ] releaseにマージ

--- a/docs/アップデート確認作業テンプレート.md
+++ b/docs/アップデート確認作業テンプレート.md
@@ -6,6 +6,7 @@
   - [ ] RESOURCEの更新
     - [ ] policy.mdの更新
     - [ ] character_info内のmetas.jsonの更新
+    - [ ] 簡易規約文面をreadme 4箇所ほどに転機
   - [ ] リリース
 - [ ] コアアップデート
   - [ ] releaseブランチ作成


### PR DESCRIPTION
## 内容

resourceの利用規約文面は管理上複数箇所に転機しないといけないのですが、結構忘れうるので項目に追加しておきました。
（まあ忘れててもCIが落ちるけど）


## その他
