### PR TITLE
docs: voicevox_vvmの更新はresourceの更新のあとなので手順を入れ替える

### DIFF
--- a/docs/hotfix確認作業テンプレート.md
+++ b/docs/hotfix確認作業テンプレート.md
@@ -1,12 +1,12 @@
-- [ ] VVMアップデート
-  - [ ] releaseにマージ
-  - [ ] リリース
 - [ ] リソースアップデート
   - [ ] releaseにマージ
   - [ ] RESOURCEの更新
     - [ ] policy.mdの更新
     - [ ] character_info内のmetas.jsonの更新
     - [ ] 簡易規約文面をreadme 4箇所ほどに転機
+  - [ ] リリース
+- [ ] VVMアップデート
+  - [ ] releaseにマージ
   - [ ] リリース
 - [ ] コアアップデート
   - [ ] releaseにマージ

--- a/docs/アップデート確認作業テンプレート.md
+++ b/docs/アップデート確認作業テンプレート.md
@@ -1,12 +1,12 @@
-- [ ] VVMアップデート
-  - [ ] releaseにマージ
-  - [ ] リリース
 - [ ] リソースアップデート
   - [ ] releaseにマージ
   - [ ] RESOURCEの更新
     - [ ] policy.mdの更新
     - [ ] character_info内のmetas.jsonの更新
     - [ ] 簡易規約文面をreadme 4箇所ほどに転機
+  - [ ] リリース
+- [ ] VVMアップデート
+  - [ ] releaseにマージ
   - [ ] リリース
 - [ ] コアアップデート
   - [ ] releaseブランチ作成


### PR DESCRIPTION
## 内容

vvmでresouceからtermを作る工程になったため。

## その他
